### PR TITLE
Use \abstractname and \keywordsname to not conflict with Babel definitions

### DIFF
--- a/arxiv.sty
+++ b/arxiv.sty
@@ -35,7 +35,7 @@
 
 
 %Handling Keywords
-\def\keywordname{{\bfseries \emph Keywords}}%
+\def\keywordname{{\bfseries \emph \keywordsname}}%
 \def\keywords#1{\par\addvspace\medskipamount{\rightskip=0pt plus1cm
 \def\and{\ifhmode\unskip\nobreak\fi\ $\cdot$
 }\noindent\keywordname\enspace\ignorespaces#1\par}}
@@ -246,7 +246,7 @@
 \renewenvironment{abstract}
 {
   \centerline
-  {\large \bfseries \scshape Abstract}
+  {\large \bfseries \scshape \abstractname}
   \begin{quote}
 }
 {


### PR DESCRIPTION
This way, using `\usepackage[language]{babel}` (or any other good translation package) will actually translate the words "Keywords" and "Abstract", e.g. `\usepackage[brazil]{babel}` will write "Palavras-chave" and "Resumo" instead of english words.

Fully compatible with current version, who write in english shouldn't need to make any changes to current documents.