### PR TITLE
Replace NIPS with NeurIPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 The project hosts an aesthetic and simple LaTeX style suitable for "preprint" publications such as arXiv and bio-arXiv, etc. 
 It is based on the [**nips_2018.sty**](https://media.nips.cc/Conferences/NIPS2018/Styles/nips_2018.sty) style.
 
-This styling maintains the esthetic of NIPS but adding and changing features to make it (IMO) even better and more suitable for preprints.
-The result looks fairly different from NIPS style so that readers won't get confused to think that the preprint was published in NIPS. 
+This styling maintains the esthetic of NeurIPS but adding and changing features to make it (IMO) even better and more suitable for preprints.
+The result looks fairly different from NeurIPS style so that readers won't get confused to think that the preprint was published in NeurIPS. 
 
-### Why NIPS? 
-Because the NIPS styling is a comfortable single column format that is very esthetic and convenient for reading.
+### Why NeurIPS? 
+Because the NeurIPS styling is a comfortable single column format that is very esthetic and convenient for reading.
 
 ## Usage:
 1. Use Document class **article**. 


### PR DESCRIPTION
To be consistent with what the [conference is called now](https://www.nature.com/articles/d41586-018-07476-w), besides being inclusive.